### PR TITLE
Allow including templates from source during PR builds

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/ @TimHess @bart-vmware

--- a/.github/workflows/build-and-stage.yml
+++ b/.github/workflows/build-and-stage.yml
@@ -13,7 +13,7 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: 'write'
+  pull-requests: write
 
 env:
   IMAGE_NAME: net-core-tool-service
@@ -33,6 +33,20 @@ jobs:
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
+    - name: Detect template source from PR body
+      run: |
+        cat << EOF > /tmp/pull_request_body.txt
+        ${{ github.event.pull_request.body }}
+        EOF
+
+        CheckoutTarget=$(grep "template_checkout_target=" /tmp/pull_request_body.txt | awk -F= '{print $2}')
+        if [ "$CheckoutTarget" = "" ]; then
+            echo "Did not find a checkout target for templates."
+        else
+            echo "Found checkout target '$CheckoutTarget' in PR body, this build will use templates from source."
+            echo "TEMPLATE_CHECKOUT_TARGET=$CheckoutTarget" >> $GITHUB_ENV
+        fi
+
     - name: Login to Azure
       uses: azure/login@v1
       with:
@@ -46,7 +60,7 @@ jobs:
         password: "${{ secrets.DOCKER_PASSWORD }}"
 
     - name: Build image
-      run: docker build . --file "Dockerfile" -t ${{ vars.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+      run: docker build . -t ${{ vars.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} --build-arg TEMPLATE_CHECKOUT_TARGET=${{ env.TEMPLATE_CHECKOUT_TARGET }}
 
     - name: Push image
       run: docker push ${{ vars.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
@@ -75,4 +89,3 @@ jobs:
 
           > *This is an automated message.*
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  

--- a/.github/workflows/build-and-stage.yml
+++ b/.github/workflows/build-and-stage.yml
@@ -34,9 +34,11 @@ jobs:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
     - name: Detect template source from PR body
+      env:
+        PullRequestBody: ${{ github.event.pull_request.body }}
       run: |
         cat << EOF > /tmp/pull_request_body.txt
-        ${{ github.event.pull_request.body }}
+        $PullRequestBody
         EOF
 
         CheckoutTarget=$(grep "template_checkout_target=" /tmp/pull_request_body.txt | awk -F= '{print $2}')
@@ -72,18 +74,18 @@ jobs:
     - name: Deploy to staging slot
       uses: azure/webapps-deploy@v3
       id: deploy-to-webapp
-      with: 
+      with:
         app-name: ${{ vars.AZURE_WEBAPP_NAME }}
         images: ${{ vars.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
         slot-name:  ${{ env.SLOT_NAME }}
-    
+
     - name: If PR, comment with the preview link
       if: ${{ github.event_name == 'pull_request' }}
       uses: mshick/add-pr-comment@v2
       with:
         message: |
-          ## Preview link: https://${{ vars.AZURE_WEBAPP_NAME }}-${{ env.SLOT_NAME }}.azurewebsites.net 
-          
+          ## Preview link: https://${{ vars.AZURE_WEBAPP_NAME }}-${{ env.SLOT_NAME }}.azurewebsites.net
+
           - Your changes have been deployed to the preview site. The preview site will update as you add more commits to this branch.
           - The preview link is shareable, but will be deleted when the pull request is merged or closed.
 

--- a/.github/workflows/build-and-stage.yml
+++ b/.github/workflows/build-and-stage.yml
@@ -1,4 +1,5 @@
 name: Build and stage
+
 on:
   push:
     branches:
@@ -20,13 +21,8 @@ env:
   IMAGE_TAG: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || github.run_id }}
 
 jobs:
-  build-push-deploy:
+  build-push:
     name: Build and push image
-    environment:
-      name: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || vars.STAGING_SLOT_NAME }}
-      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
-    env:
-      SLOT_NAME: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || vars.STAGING_SLOT_NAME }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -49,11 +45,6 @@ jobs:
             echo "TEMPLATE_CHECKOUT_TARGET=$CheckoutTarget" >> $GITHUB_ENV
         fi
 
-    - name: Login to Azure
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-
     - name: Login to container registry
       uses: azure/docker-login@v1
       with:
@@ -67,13 +58,29 @@ jobs:
     - name: Push image
       run: docker push ${{ vars.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
 
+  deploy:
+    name: Deploy
+    if: ${{ github.secret_source == 'Actions' }}
+    environment:
+      name: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || vars.STAGING_SLOT_NAME }}
+      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+    env:
+      SLOT_NAME: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || vars.STAGING_SLOT_NAME }}
+    needs: build-push
+    runs-on: ubuntu-latest
+    steps:
+    - name: Login to Azure
+      uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
     - name: If PR, create a new staging slot
       if: ${{ github.event_name == 'pull_request' }}
       run: az webapp deployment slot create --resource-group ${{ vars.AZURE_RESOURCE_GROUP }} --name ${{ vars.AZURE_WEBAPP_NAME}} --slot ${{ env.SLOT_NAME }} --configuration-source ${{ vars.STAGING_SLOT_NAME }}
 
     - name: Deploy to staging slot
-      uses: azure/webapps-deploy@v3
       id: deploy-to-webapp
+      uses: azure/webapps-deploy@v3
       with:
         app-name: ${{ vars.AZURE_WEBAPP_NAME }}
         images: ${{ vars.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -23,7 +23,6 @@ jobs:
 
   delete-deployment:
     runs-on: ubuntu-latest
-    permissions: write-all
 
     steps:
       - name: Delete Deployment Environment
@@ -31,3 +30,4 @@ jobs:
         with:
           environment: "pr-${{ github.event.number }}"
           token: ${{ secrets.GITHUB_TOKEN }}
+          onlyRemoveDeployments: true

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -2,7 +2,8 @@ name: Delete a preview environment
 
 on:
   pull_request:
-    types: [closed]
+    types:
+    - closed
 
 env:
   SLOT_NAME: pr-${{ github.event.number }}
@@ -13,20 +14,20 @@ jobs:
 
     steps:
     - name: Log into Azure CLI with service principal
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
+
     - name: Delete slot on staging site
       run: az webapp deployment slot delete --resource-group ${{ vars.AZURE_RESOURCE_GROUP }} --name ${{ vars.AZURE_WEBAPP_NAME}} --slot ${{ env.SLOT_NAME }}
 
   delete-deployment:
     runs-on: ubuntu-latest
+    permissions: write-all
 
     steps:
       - name: Delete Deployment Environment
-        uses: strumwolf/delete-deployment-environment@v2
+        uses: strumwolf/delete-deployment-environment@v3
         with:
           environment: "pr-${{ github.event.number }}"
           token: ${{ secrets.GITHUB_TOKEN }}
-          onlyRemoveDeployments: true

--- a/.github/workflows/stage-prod-swap.yml
+++ b/.github/workflows/stage-prod-swap.yml
@@ -8,15 +8,14 @@ jobs:
     name: Promote to production
     runs-on: ubuntu-latest
     environment:
-      name: 'Production'
+      name: Production
       url: 'https://${{ vars.AZURE_WEBAPP_NAME }}.azurewebsites.net/'
 
     steps:
     - name: Log into Azure CLI with service principal
-      uses: azure/login@v1
+      uses: azure/login@v2
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: Swap slots
       run: az webapp deployment slot swap -s ${{ vars.STAGING_SLOT_NAME }} -n ${{ vars.AZURE_WEBAPP_NAME }} -g ${{ vars.AZURE_RESOURCE_GROUP }}
-    

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,17 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /source
 COPY . .
-RUN dotnet restore
-RUN dotnet publish -c release -o /srv --no-restore
+RUN dotnet restore src/NetCoreToolService
+RUN dotnet build src/NetCoreToolService --configuration Release --no-restore
+RUN dotnet publish src/NetCoreToolService --output /srv --no-build
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine
 ARG templates_version=1.3.0
-#RUN dotnet nuget add source https://pkgs.dev.azure.com/dotnet/Steeltoe/_packaging/dev/nuget/v3/index.json -n SteeltoeDev
-RUN dotnet new --install Steeltoe.NetCoreTool.Templates::${templates_version} &&\
-      dotnet new --list | grep steeltoe-webapi
-# WORKDIR /usr/local/src
-# RUN git clone https://github.com/SteeltoeOSS/NetCoreToolTemplates
-# RUN git -C NetCoreToolTemplates checkout release/1.2
-# RUN dotnet new --install NetCoreToolTemplates/src/Content
+ARG TEMPLATE_CHECKOUT_TARGET
 WORKDIR /srv
 COPY --from=build /srv .
-ENV DOTNET_URLS http://0.0.0.0:80
+COPY install-template.sh /srv/install-template.sh
+RUN chmod +x /srv/install-template.sh
+RUN /srv/install-template.sh
+ENV DOTNET_URLS=http://0.0.0.0:80
 ENTRYPOINT ["dotnet", "Steeltoe.NetCoreToolService.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN dotnet build src/NetCoreToolService --configuration Release --no-restore
 RUN dotnet publish src/NetCoreToolService --output /srv --no-build
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine
-ARG templates_version=1.3.0
+ARG templates_version=1.4.0
 ARG TEMPLATE_CHECKOUT_TARGET
 WORKDIR /srv
 COPY --from=build /srv .

--- a/Steeltoe.NetCoreToolService.sln
+++ b/Steeltoe.NetCoreToolService.sln
@@ -19,8 +19,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		docker-compose.yaml = docker-compose.yaml
 		Dockerfile = Dockerfile
+		install-template.sh = install-template.sh
 		stylecop.json = stylecop.json
 		Version.props = Version.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{4D3C2BC0-3714-42D2-BB89-057E57D92BAF}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-and-stage.yml = .github\workflows\build-and-stage.yml
+		.github\workflows\pr-cleanup.yml = .github\workflows\pr-cleanup.yml
+		.github\workflows\stage-prod-swap.yml = .github\workflows\stage-prod-swap.yml
 	EndProjectSection
 EndProject
 Global
@@ -64,6 +74,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1462EDFE-F1FC-48C2-80C1-917317EE3C97} = {C742A7B8-80CA-4365-85CA-C29AA744CE54}
 		{6BD6C793-E555-475F-A2E1-12D7F3F56A3B} = {410C0E72-737F-4168-AECA-2F6D19EE86D5}
+		{4D3C2BC0-3714-42D2-BB89-057E57D92BAF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8EFB01A-92BF-418B-B2B2-A12045B772E2}

--- a/install-template.sh
+++ b/install-template.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# dotnet nuget add source https://pkgs.dev.azure.com/dotnet/Steeltoe/_packaging/dev/nuget/v3/index.json -n SteeltoeDev
+
+if [[ -z "$TEMPLATE_CHECKOUT_TARGET" ]] ;then
+    dotnet new install Steeltoe.NetCoreTool.Templates::${templates_version} &&\
+      dotnet new --list | grep steeltoe-webapi
+else
+    cd /usr/local/src
+    git clone https://github.com/SteeltoeOSS/NetCoreToolTemplates
+    git -C NetCoreToolTemplates checkout $TEMPLATE_CHECKOUT_TARGET
+    dotnet new install NetCoreToolTemplates/src/Content
+fi


### PR DESCRIPTION
- separate build and deploy as unique jobs (so we can re-run deployment to staging after a stage/prod swap)
- update action versions
- align styles with other Steeltoe GH Actions
- alter the GitHub actions and dockerfile to add support for including templates built from source code rather than nuget.org.

Use the syntax below for specifying what should be checked out:

template_checkout_target=update-for-Steeltoe-v4